### PR TITLE
[HW]1072947

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ echo "Example 1" > ex1.txt
 [注意] 只能有"一筆"commit
 
 3. 在 ncyu-2021-ex1 資料夾下, 執行以下指令
+由於只能有一筆commit，所以當我們bash錯誤後重新bash，便會出現Your commit number is more than 1 此時可以到使用者資料夾將整個ncyu-2021-ex1檔案刪除再重新操作即可
 
 ```
 bash <(curl -s https://raw.githubusercontent.com/jrjang/ncyu-2021/ex1/scripts/ex1-test.sh) GITHUB_ACCOUNT

--- a/ex1.txt
+++ b/ex1.txt
@@ -1,0 +1,1 @@
+Example 1

--- a/ex1.txt
+++ b/ex1.txt
@@ -1,1 +1,0 @@
-Example 1


### PR DESCRIPTION
要解決問題:由於只能有一筆commit,所以當我們bash錯誤後重新bash，便會出現Your commit number is more than 1
如何解決:可以到使用者資料夾將整個ncyu-2021-ex1檔案刪除再重新操作即可