### PR TITLE
[HW] 1072947

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ echo "Example 1" > ex1.txt
 
 3. 在 ncyu-2021-ex1 資料夾下, 執行以下指令
 
+[注意] 如果出現 Your commit number is more than 1 ，請刪除 ncyu-2021-ex1 資料夾，重新執行
+
 ```
 bash <(curl -s https://raw.githubusercontent.com/jrjang/ncyu-2021/ex1/scripts/ex1-test.sh) GITHUB_ACCOUNT
 ```


### PR DESCRIPTION
要解決問題:由於只能有一筆commit，所以當我們bash的結果錯誤，重新操作完整個流程再次bash，便會出現Your commit number is more than 1
如何解決:可以到使用者資料夾將整個ncyu-2021-ex1檔案刪除，重新操作完整個流程再次bash即可
Signed-off-by: 1072947 <s1072947@mail.ncyu.edu.tw>